### PR TITLE
Updates for ColdBox 6 module slug fix

### DIFF
--- a/Application.cfc
+++ b/Application.cfc
@@ -29,6 +29,9 @@ component{
 
 	// request start
 	public boolean function onRequestStart(String targetPage){
+		if ( ! application.keyExists( "cbBootstrap" ) ) {
+			onApplicationStart();
+		}
 		// Process ColdBox Request
 		application.cbBootstrap.onRequestStart( arguments.targetPage );
 

--- a/box.json
+++ b/box.json
@@ -11,9 +11,9 @@
         "testbox":"stable"
     },
     "installPaths":{
-        "testbox":"testbox",
-        "coldbox":"coldbox",
-        "workbench":"workbench"
+        "testbox":"testbox/",
+        "coldbox":"coldbox/",
+        "workbench":"workbench/"
     },
     "testbox":{
         "runner":"http://localhost:49616/tests/runner.cfm"

--- a/config/Coldbox.cfc
+++ b/config/Coldbox.cfc
@@ -70,12 +70,7 @@ component{
 		};
 
 		//Register interceptors as an array, we need order
-		interceptors = [
-			//SES
-			{class="coldbox.system.interceptors.SES",
-			 properties={}
-			}
-		];
+		interceptors = [];
 
 		moduleSettings = {
 

--- a/modules/cbfreshbooks/box.json
+++ b/modules/cbfreshbooks/box.json
@@ -3,7 +3,7 @@
     "author": "Ortus Solutions <info@ortussolutions.com",
     "location": "http://downloads.ortussolutions.com.s3.amazonaws.com/ortussolutions/coldbox-modules/cbfreshbooks/@build.version@/cbfreshbooks-@build.version@.zip",
     "version": "@build.version@+@build.number@",
-    "slug": "cbModule",
+    "slug":"cbfreshbooks",
     "type": "modules",
     "homepage": "https://github.com/coldbox-modules/cbox-freshbooksSDK",
     "bugs": "https://github.com/coldbox-modules/cbox-freshbooksSDK/issues",


### PR DESCRIPTION
The README says this module exists at `forgebox.io/view/cbfreshbooks`. Personally, I think that's way better than `cbModule`. :smile: 

Also, ColdBox 6 updates: Drop the SES interceptor, and ensure the `cbBootstrap` variable exists prior to onRequestStart. (defensive coding.)